### PR TITLE
Provide Imports and  Require variable names

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ npm install --save konan
 const konan = require('konan')
 
 konan(`
-import React, {Component} from 'react'
+import {React, Component} from 'react';
 const vue = require('vue/dist/vue')
 import('./my-async-module').then()
 require(path.resolve('./'))
@@ -34,7 +34,12 @@ require(path.resolve('./'))
 result =>
 {
   strings: ['react', 'vue/dist/vue', './my-async-module'],
-  expressions: ['path.resolve(\'./\')']
+  expressions: ['path.resolve(\'./\')'],
+  imports: {
+    react: ['React', 'Component'],
+    './my-async-module': ['default'],
+    'vue/dist/vue': [vue']
+  }
 } 
 */
 ```

--- a/index.js
+++ b/index.js
@@ -23,19 +23,52 @@ module.exports = function(
 
   const storeNamedImports = node => {
     if (node.specifiers) {
-      const imported = node.specifiers.map(specifier => specifier.imported || specifier.local);
+      const imported = node.specifiers.map(
+        specifier => specifier.imported || specifier.local
+      )
       if (imported) {
-        const imports = imported.map(indentifier => indentifier && indentifier.name);
+        const imports = imported.map(
+          indentifier => indentifier && indentifier.name
+        )
         if (!Reflect.has(modules.imports, node.source.value)) {
-          modules.imports[node.source.value] = [];
+          modules.imports[node.source.value] = []
         }
-        modules.imports[node.source.value] = imports;
+        modules.imports[node.source.value] = imports
       }
     }
   }
 
-  let prevNode;
-  let prevPath;
+  const processAncestor = (prevPath, arg) => {
+    if (
+      Reflect.has(prevPath.parentPath, 'parentPath') &&
+      prevPath.parentPath.parentPath instanceof Object
+    ) {
+      const ancestor = prevPath.parentPath.parentPath.parent
+
+      if (ancestor.type === 'VariableDeclarator') {
+        const namedProps = ancestor.id.properties.map(
+          property => property.key.name
+        )
+        if (!Reflect.has(modules.imports, arg.value)) {
+          modules.imports[arg.value] = []
+        }
+        modules.imports[arg.value].push(...namedProps)
+        return namedProps
+      }
+
+      if (ancestor.type === 'Program' && Reflect.has(prevPath.parent, 'id')) {
+        const variableDeclarator = prevPath
+        const requireVariableName = variableDeclarator.parent.id.name
+        if (!Reflect.has(modules.imports, arg.value)) {
+          modules.imports[arg.value] = []
+        }
+        modules.imports[arg.value].push(requireVariableName)
+        return requireVariableName
+      }
+    }
+  }
+
+  let prevPath
 
   traverse(ast, {
     enter(path) {
@@ -45,34 +78,19 @@ module.exports = function(
         if (callee.isIdentifier({ name: 'require' }) || isDynamicImport) {
           const arg = path.node.arguments[0]
           if (arg.type === 'StringLiteral') {
-            modules.strings.push(arg.value);
+            modules.strings.push(arg.value)
 
-            if (Reflect.has(prevPath.parentPath, 'parentPath') && prevPath.parentPath.parentPath instanceof Object) {
-              const ancestor = prevPath.parentPath.parentPath.parent;
-
-              if (ancestor.type === 'VariableDeclarator') {
-                const namedProps = ancestor.id.properties.map(property => property.key.name);
-                if (!Reflect.has(modules.imports, arg.value)) {
-                  modules.imports[arg.value] = [];
-                }
-                modules.imports[arg.value].push(...namedProps);
-                return
-              }
-
-              if (ancestor.type === 'Program' && Reflect.has(prevPath.parent, 'id')) {
-                const variableDeclarator = prevPath;
-                console.log(variableDeclarator.parent.id.name);
-                const requireVariableName = variableDeclarator.parent.id.name;
-                if (!Reflect.has(modules.imports, arg.value)) {
-                  modules.imports[arg.value] = [];
-                }
-                modules.imports[arg.value].push(requireVariableName);
-                return;
-              }
+            const importNames = processAncestor(prevPath, arg)
+            if (importNames) {
+              return
             }
 
-            if (Reflect.has(path.node, 'arguments') && path.node.arguments.length > 0 && path.node.arguments[0].type === 'StringLiteral') {
-              modules.imports[arg.value] = ['default'];
+            if (
+              Reflect.has(path.node, 'arguments') &&
+              path.node.arguments.length > 0 &&
+              path.node.arguments[0].type === 'StringLiteral'
+            ) {
+              modules.imports[arg.value] = ['default']
             }
           } else {
             modules.expressions.push(src.slice(arg.start, arg.end))
@@ -82,17 +100,17 @@ module.exports = function(
         path.node.type === 'ImportDeclaration' ||
         path.node.type === 'ExportNamedDeclaration' ||
         path.node.type === 'ExportAllDeclaration'
-        ) {
-          const { source } = path.node
-          if (source && source.value) {
-            modules.strings.push(source.value)
-            storeNamedImports(path.node);
-          }
+      ) {
+        const { source } = path.node
+        if (source && source.value) {
+          modules.strings.push(source.value)
+          storeNamedImports(path.node)
         }
-
-        prevPath = path
       }
-    })
+
+      prevPath = path
+    }
+  })
 
   return modules
 }

--- a/index.js
+++ b/index.js
@@ -22,23 +22,13 @@ module.exports = function(
   }
 
   const storeNamedImports = node => {
-
-    // console.log(node);
-
     if (node.specifiers) {
-      // console.log('................');
-      // console.log(path.node)
       const imported = node.specifiers.map(specifier => specifier.imported || specifier.local);
       if (imported) {
-        // console.log(imported);
-
         const imports = imported.map(indentifier => indentifier && indentifier.name);
-        // console.log(imports);
-
         if (!Reflect.has(modules.imports, node.source.value)) {
           modules.imports[node.source.value] = [];
         }
-
         modules.imports[node.source.value] = imports;
       }
     }

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ module.exports = function(
   src,
   { dynamicImport = true, parse = { sourceType: 'module', plugins: '*' } } = {}
 ) {
-  const modules = { strings: [], expressions: [] }
+  const modules = { imports: {}, strings: [], expressions: [] }
 
   let ast
 
@@ -21,31 +21,83 @@ module.exports = function(
     ast = src
   }
 
+  const storeNamedImports = node => {
+
+    // console.log(node);
+
+    if (node.specifiers) {
+      // console.log('................');
+      // console.log(path.node)
+      const imported = node.specifiers.map(specifier => specifier.imported || specifier.local);
+      if (imported) {
+        // console.log(imported);
+
+        const imports = imported.map(indentifier => indentifier && indentifier.name);
+        // console.log(imports);
+
+        if (!Reflect.has(modules.imports, node.source.value)) {
+          modules.imports[node.source.value] = [];
+        }
+
+        modules.imports[node.source.value] = imports;
+      }
+    }
+  }
+
+  let prevNode;
+  let prevPath;
+
   traverse(ast, {
     enter(path) {
+      // console.log(path.node);
+      // console.log(path.node.type);
+
+
       if (path.node.type === 'CallExpression') {
         const callee = path.get('callee')
         const isDynamicImport = dynamicImport && callee.isImport()
         if (callee.isIdentifier({ name: 'require' }) || isDynamicImport) {
           const arg = path.node.arguments[0]
           if (arg.type === 'StringLiteral') {
-            modules.strings.push(arg.value)
+            modules.strings.push(arg.value);
+
+            // console.log(prevPath.parentPath);
+            if (Reflect.has(prevPath.parentPath, 'parentPath') && prevPath.parentPath.parentPath instanceof Object) {
+              const variableDeclarator = prevPath.parentPath.parentPath.parent;
+              const namedProps = variableDeclarator.id.properties.map(property => property.key.name);
+              if (!Reflect.has(modules.imports, arg.value)) {
+                modules.imports[arg.value] = [];
+              }
+              modules.imports[arg.value].push(...namedProps);
+              return
+            }
+
+            if (Reflect.has(path.node, 'arguments') && path.node.arguments.length > 0 && path.node.arguments[0].type === 'StringLiteral') {
+              modules.imports[arg.value] = ['default'];
+            }
+
           } else {
             modules.expressions.push(src.slice(arg.start, arg.end))
           }
+          // storeNamedImports(path.node);
         }
       } else if (
         path.node.type === 'ImportDeclaration' ||
         path.node.type === 'ExportNamedDeclaration' ||
         path.node.type === 'ExportAllDeclaration'
-      ) {
-        const { source } = path.node
-        if (source && source.value) {
-          modules.strings.push(source.value)
+        ) {
+          // console.log(path.node);
+
+          const { source } = path.node
+          if (source && source.value) {
+            modules.strings.push(source.value)
+            storeNamedImports(path.node);
+          }
         }
+
+        prevPath = path
       }
-    }
-  })
+    })
 
   return modules
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   ],
   "scripts": {
     "test": "jest && npm run lint",
-    "lint": "xo index.js __test__/*.test.js"
+    "lint": "xo index.js test/*.test.js"
   },
   "author": "egoist <0x142857@gmail.com>",
   "license": "MIT",

--- a/test/fixture-readme-example.js
+++ b/test/fixture-readme-example.js
@@ -1,0 +1,6 @@
+import React, {Component} from 'react'
+const {vue} = require('vue/dist/vue')
+const other = require('other/bin')
+import('./my-async-module').then()
+import('./my-async-module2')
+require(path.resolve('./'))

--- a/test/fixture2.js
+++ b/test/fixture2.js
@@ -1,0 +1,22 @@
+import {foo, bar, qux as fizz} from 'baz'
+
+import hahah from 'vue/dist/vue'
+
+import {
+  hello
+} from 'wow'
+
+const {
+  hello2,
+  hello3
+} = require('baby')
+
+import('./async-module')
+
+var a = {
+  import: 'foo1',
+  require: 'bar1',
+  lol: 'baz1'
+}
+
+const b = <div>jsx no-mad!</div>

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -4,12 +4,19 @@ const konan = require('../')
 describe('main', () => {
   const input = fs.readFileSync('./test/fixture.js', 'utf8')
   const input2 = fs.readFileSync('./test/fixture2.js', 'utf8')
-  const readmeExample = fs.readFileSync('./test/fixture-readme-example.js', 'utf8')
+  const readmeExample = fs.readFileSync(
+    './test/fixture-readme-example.js',
+    'utf8'
+  )
 
   test('all', () => {
-    expect(konan(input).strings).toEqual(
-      ['foo', 'vue/dist/vue', 'wow', 'baby', './async-module']
-    )
+    expect(konan(input).strings).toEqual([
+      'foo',
+      'vue/dist/vue',
+      'wow',
+      'baby',
+      './async-module'
+    ])
   })
 
   test('all named imports', () => {
@@ -19,13 +26,16 @@ describe('main', () => {
       wow: ['hello'],
       baby: ['hello2', 'hello3'],
       './async-module': ['default']
-    });
+    })
   })
 
   test('exclude dynamical import', () => {
-    expect(konan(input, { dynamicImport: false }).strings).toEqual(
-      ['foo', 'vue/dist/vue', 'wow', 'baby'],
-    )
+    expect(konan(input, { dynamicImport: false }).strings).toEqual([
+      'foo',
+      'vue/dist/vue',
+      'wow',
+      'baby'
+    ])
   })
 
   test('dynamical require', () => {
@@ -37,7 +47,7 @@ describe('main', () => {
     ).toEqual({
       strings: ['bar'],
       expressions: ["path.resolve('./')"],
-      imports: {bar: ['default']}
+      imports: { bar: ['default'] }
     })
   })
 
@@ -52,7 +62,7 @@ describe('main', () => {
     ).toEqual({
       strings: ['foo'],
       expressions: [],
-      imports: {foo: ['default']}
+      imports: { foo: ['default'] }
     })
   })
 
@@ -60,17 +70,17 @@ describe('main', () => {
     expect(konan(`import * as m from 'm';var foo = {import: 'mm'}`)).toEqual({
       strings: ['m'],
       expressions: [],
-      imports: {m: ['m']}
+      imports: { m: ['m'] }
     })
   })
 
   test('README example', () => {
     expect(konan(readmeExample).imports).toEqual({
-      react: [ 'React', 'Component' ],
-      'vue/dist/vue': [ 'vue' ],
-      'other/bin': [ 'other' ],
-      './my-async-module': [ 'default' ],
-      './my-async-module2': [ 'default' ]
+      react: ['React', 'Component'],
+      'vue/dist/vue': ['vue'],
+      'other/bin': ['other'],
+      './my-async-module': ['default'],
+      './my-async-module2': ['default']
     })
   })
 
@@ -81,16 +91,11 @@ describe('main', () => {
       expressions: [],
       imports: {
         './persistent': [
-          "MDCPersistentDrawer",
-          "MDCPersistentDrawerFoundation"
+          'MDCPersistentDrawer',
+          'MDCPersistentDrawerFoundation'
         ],
-        './temporary': [
-          "MDCTemporaryDrawer",
-          "MDCTemporaryDrawerFoundation"
-        ],
-        './util': [
-          'util'
-        ]
+        './temporary': ['MDCTemporaryDrawer', 'MDCTemporaryDrawerFoundation'],
+        './util': ['util']
       }
     })
   })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -4,6 +4,7 @@ const konan = require('../')
 describe('main', () => {
   const input = fs.readFileSync('./test/fixture.js', 'utf8')
   const input2 = fs.readFileSync('./test/fixture2.js', 'utf8')
+  const readmeExample = fs.readFileSync('./test/fixture-readme-example.js', 'utf8')
 
   test('all', () => {
     expect(konan(input).strings).toEqual(
@@ -60,6 +61,16 @@ describe('main', () => {
       strings: ['m'],
       expressions: [],
       imports: {m: ['m']}
+    })
+  })
+
+  test('README example', () => {
+    expect(konan(readmeExample).imports).toEqual({
+      react: [ 'React', 'Component' ],
+      'vue/dist/vue': [ 'vue' ],
+      'other/bin': [ 'other' ],
+      './my-async-module': [ 'default' ],
+      './my-async-module2': [ 'default' ]
     })
   })
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -3,19 +3,28 @@ const konan = require('../')
 
 describe('main', () => {
   const input = fs.readFileSync('./test/fixture.js', 'utf8')
+  const input2 = fs.readFileSync('./test/fixture2.js', 'utf8')
 
   test('all', () => {
-    expect(konan(input)).toEqual({
-      strings: ['foo', 'vue/dist/vue', 'wow', 'baby', './async-module'],
-      expressions: []
-    })
+    expect(konan(input).strings).toEqual(
+      ['foo', 'vue/dist/vue', 'wow', 'baby', './async-module']
+    )
+  })
+
+  test('all named imports', () => {
+    expect(konan(input2).imports).toEqual({
+      baz: ['foo', 'bar', 'qux'],
+      'vue/dist/vue': ['hahah'],
+      wow: ['hello'],
+      baby: ['hello2', 'hello3'],
+      './async-module': ['default']
+    });
   })
 
   test('exclude dynamical import', () => {
-    expect(konan(input, { dynamicImport: false })).toEqual({
-      strings: ['foo', 'vue/dist/vue', 'wow', 'baby'],
-      expressions: []
-    })
+    expect(konan(input, { dynamicImport: false }).strings).toEqual(
+      ['foo', 'vue/dist/vue', 'wow', 'baby'],
+    )
   })
 
   test('dynamical require', () => {
@@ -26,7 +35,8 @@ describe('main', () => {
     `)
     ).toEqual({
       strings: ['bar'],
-      expressions: ["path.resolve('./')"]
+      expressions: ["path.resolve('./')"],
+      imports: {bar: ['default']}
     })
   })
 
@@ -40,14 +50,16 @@ describe('main', () => {
     `)
     ).toEqual({
       strings: ['foo'],
-      expressions: []
+      expressions: [],
+      imports: {foo: ['default']}
     })
   })
 
   test('import *', () => {
     expect(konan(`import * as m from 'm';var foo = {import: 'mm'}`)).toEqual({
       strings: ['m'],
-      expressions: []
+      expressions: [],
+      imports: {m: ['m']}
     })
   })
 
@@ -55,7 +67,20 @@ describe('main', () => {
     const input = fs.readFileSync('./test/fixture-export.js', 'utf8')
     expect(konan(input)).toEqual({
       strings: ['./util', './temporary', './persistent', 'all'],
-      expressions: []
+      expressions: [],
+      imports: {
+        './persistent': [
+          "MDCPersistentDrawer",
+          "MDCPersistentDrawerFoundation"
+        ],
+        './temporary': [
+          "MDCTemporaryDrawer",
+          "MDCTemporaryDrawerFoundation"
+        ],
+        './util': [
+          'util'
+        ]
+      }
     })
   })
 })


### PR DESCRIPTION
Added ability to get names of imports:

```js
import {foo, bar, qux as fizz} from 'baz'
```
..yeilds...

```js
 result = {
  expressions: [],
  strings: ['baz'],
  imports: {
    baz: ['foo', 'bar', 'qux']
  }
}
```
... and so-on.